### PR TITLE
add env file to use in deno.jsonc

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,7 +1,7 @@
 {
 	"tasks": {
-		"dev": "deno run --watch --allow-env --allow-read --allow-write --allow-net --allow-ffi --allow-run main.ts",
-		"start": "deno run --allow-env --allow-read --allow-write --allow-net --allow-ffi --allow-run main.ts"
+		"dev": "deno run --watch --allow-env --allow-read --allow-write --allow-net --allow-ffi --allow-run --env-file=.env main.ts",
+		"start": "deno run --allow-env --allow-read --allow-write --allow-net --allow-ffi --allow-run --env-file=.env main.ts"
 	},
 	"lint": {
 		"rules": {


### PR DESCRIPTION
Adds `--env-file=.env` to the tasks list in deno.jsonc, it requires this to read environment variables